### PR TITLE
Update for recent versions of react native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,10 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
   compileSdkVersion 23
   buildToolsVersion "23.0.1"
@@ -30,5 +34,5 @@ repositories {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.15.+'
+  implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 }

--- a/android/src/main/java/com/yoloci/fileupload/FileUploadPackage.java
+++ b/android/src/main/java/com/yoloci/fileupload/FileUploadPackage.java
@@ -30,7 +30,7 @@ public class FileUploadPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Read React native version from the root projects ext. Fallback to "com.facebook.react:react-native:+"

As of RN 0.47 createJSModules is no longer defined in the parent ReactPackage Class.
So the @Override throws an error when building.
https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8
